### PR TITLE
Add "holdings locked" reject message code.

### DIFF
--- a/dist/golang/actions/resources.go
+++ b/dist/golang/actions/resources.go
@@ -4541,6 +4541,9 @@ const (
 	// HoldingsFrozen - Holdings are frozen, so the request can't be completed.
 	RejectionsHoldingsFrozen = 32
 
+	// HoldingsLocked - Holdings are locked by a multi-contract request, so the request can't be completed yet.
+	RejectionsHoldingsLocked = 33
+
 	// HolderProposalProhibited - Holders are not permitted to make proposals.
 	RejectionsHolderProposalProhibited = 40
 
@@ -4757,6 +4760,13 @@ func RejectionsData(code uint32) *RejectionsCode {
 			Name:        "HoldingsFrozen",
 			Label:       "Holdings Frozen",
 			Description: "Holdings are frozen, so the request can't be completed.",
+			MetaData:    `{}`,
+		}
+	case RejectionsHoldingsLocked:
+		return &RejectionsCode{
+			Name:        "HoldingsLocked",
+			Label:       "Holdings Locked",
+			Description: "Holdings are locked by a multi-contract request, so the request can't be completed yet.",
 			MetaData:    `{}`,
 		}
 	case RejectionsHolderProposalProhibited:
@@ -4977,6 +4987,11 @@ func RejectionsMap() map[uint32]*RejectionsCode {
 			Name:        "HoldingsFrozen",
 			Label:       "Holdings Frozen",
 			Description: "Holdings are frozen, so the request can't be completed.",
+		},
+		RejectionsHoldingsLocked: &RejectionsCode{
+			Name:        "HoldingsLocked",
+			Label:       "Holdings Locked",
+			Description: "Holdings are locked by a multi-contract request, so the request can't be completed yet.",
 		},
 		RejectionsHolderProposalProhibited: &RejectionsCode{
 			Name:        "HolderProposalProhibited",

--- a/dist/json/actions.json
+++ b/dist/json/actions.json
@@ -2499,7 +2499,7 @@
       "description": "Used to reject request actions that do not comply with the Contract. If money is to be returned to a User then it is used in lieu of the Settlement Action to properly account for token balances. All Administration/User request Actions must be responded to by the Contract with an Action.  The only exception to this rule is when there is not enough fees in the first Action for the Contract response action to remain revenue neutral.  If not enough fees are attached to pay for the Contract response then the Contract will not respond.",
       "fields": [
         {
-          "description": "Associates the message to a particular output by the index.",
+          "description": "Associates the message to a particular output by the index. If none are specified then the first output is assumed.",
           "label": "Address Indexes",
           "name": "AddressIndexes",
           "size": 4,
@@ -5708,6 +5708,12 @@
           "description": "Holdings are frozen, so the request can't be completed.",
           "label": "Holdings Frozen",
           "name": "HoldingsFrozen"
+        },
+        {
+          "code": 33,
+          "description": "Holdings are locked by a multi-contract request, so the request can't be completed yet.",
+          "label": "Holdings Locked",
+          "name": "HoldingsLocked"
         },
         {
           "code": 40,

--- a/dist/markdown/protocol-actions.md
+++ b/dist/markdown/protocol-actions.md
@@ -3463,7 +3463,7 @@ Used to reject request actions that do not comply with the Contract. If money is
             uint(4)[tiny]
         </td>
         <td>
-            Associates the message to a particular output by the index.
+            Associates the message to a particular output by the index. If none are specified then the first output is assumed.
             
         </td>
     </tr>

--- a/dist/markdown/protocol-resources.md
+++ b/dist/markdown/protocol-resources.md
@@ -504,6 +504,7 @@ Code/Text combinations returned in rejection messages when a request is not acce
 - TransferSelf
 - TransferExpired
 - HoldingsFrozen
+- HoldingsLocked
 - HolderProposalProhibited
 - ProposalConflicts
 - VoteNotFound

--- a/src/actions/develop/actions/M2 - Rejection.yaml
+++ b/src/actions/develop/actions/M2 - Rejection.yaml
@@ -24,7 +24,7 @@ metadata:
 fields:
   - name: AddressIndexes
     label: Address Indexes
-    description: "Associates the message to a particular output by the index."
+    description: "Associates the message to a particular output by the index. If none are specified then the first output is assumed."
     type: uint[]
     size: 4
 

--- a/src/resources/develop/Rejections.yaml
+++ b/src/resources/develop/Rejections.yaml
@@ -133,6 +133,11 @@ values:
     label: Holdings Frozen
     description: Holdings are frozen, so the request can't be completed.
 
+  - code: 33
+    name: HoldingsLocked
+    label: Holdings Locked
+    description: Holdings are locked by a multi-contract request, so the request can't be completed yet.
+
 #################################### Governance ####################################
 
   - code: 40


### PR DESCRIPTION
Add a "holdings locked" reject message that can be used when an address' holdings are locked for a pending multi-contract transfer and another transfer is requested on that address.