### PR TITLE
Add var size for asset fields

### DIFF
--- a/dist/markdown/protocol-assets.md
+++ b/dist/markdown/protocol-assets.md
@@ -70,7 +70,7 @@ A Membership
     <tr>
         <td>ID</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -81,7 +81,7 @@ A Membership
     <tr>
         <td>MembershipClass</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -92,7 +92,7 @@ A Membership
     <tr>
         <td>RoleType</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -103,7 +103,7 @@ A Membership
     <tr>
         <td>MembershipType</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -114,7 +114,7 @@ A Membership
     <tr>
         <td>Description</td>
         <td>
-            varchar
+            varchar(small)
         </td>
         <td>
             
@@ -151,7 +151,7 @@ Currency, fiat money, cash.  Issued by a monetary authority (eg. Reserve Bank of
     <tr>
         <td>MonetaryAuthority</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -162,7 +162,7 @@ Currency, fiat money, cash.  Issued by a monetary authority (eg. Reserve Bank of
     <tr>
         <td>Description</td>
         <td>
-            varchar
+            varchar(small)
         </td>
         <td>
             
@@ -210,7 +210,7 @@ Common stock represents ownership interests in companies.
     <tr>
         <td>Description</td>
         <td>
-            varchar
+            varchar(small)
         </td>
         <td>
             
@@ -236,7 +236,7 @@ A voucher entitling the holder to a discount on a particular product or service.
     <tr>
         <td>RedeemingEntity</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             The entity responsible for redemption of this coupon.
@@ -291,7 +291,7 @@ A voucher entitling the holder to a discount on a particular product or service.
     <tr>
         <td>Description</td>
         <td>
-            varchar
+            varchar(small)
         </td>
         <td>
             
@@ -328,7 +328,7 @@ A Loyalty Point
     <tr>
         <td>OfferName</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -361,7 +361,7 @@ A Loyalty Point
     <tr>
         <td>Description</td>
         <td>
-            varchar
+            varchar(small)
         </td>
         <td>
             
@@ -409,7 +409,7 @@ Admission ticket
     <tr>
         <td>Venue</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -420,7 +420,7 @@ Admission ticket
     <tr>
         <td>Class</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -431,7 +431,7 @@ Admission ticket
     <tr>
         <td>Area</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -442,7 +442,7 @@ Admission ticket
     <tr>
         <td>Seat</td>
         <td>
-            varchar
+            varchar(tiny)
         </td>
         <td>
             
@@ -486,7 +486,7 @@ Admission ticket
     <tr>
         <td>Description</td>
         <td>
-            varchar
+            varchar(small)
         </td>
         <td>
             

--- a/internal/markdown/templates/protocol-assets.tpl
+++ b/internal/markdown/templates/protocol-assets.tpl
@@ -12,7 +12,7 @@
           {{- else if .IsCompoundType }}
             <a href="#type-{{kebabcase .BaseType}}">{{.BaseType}}[{{.Size}}]</a>
           {{- else}}
-            {{.BaseType}}[{{.Size}}]
+            {{.MarkdownType}}
           {{- end}}
         {{- else}}
           {{- if .IsAlias }}
@@ -20,7 +20,7 @@
           {{- else if .IsCompoundType }}
             <a href="#type-{{kebabcase .BaseType}}">{{.Type}}</a>{{ if ne .Size 0 }}({{.Size}}){{ end }}
           {{- else}}
-            {{.Type}}{{ if ne .Size 0 }}({{.Size}}){{ end }}
+            {{.MarkdownType}}
           {{- end}}
         {{- end}}
         </td>


### PR DESCRIPTION
The varbin and varchar fields were just using base type and list size, but not displaying the variable size using the markdown type for the assets template.